### PR TITLE
log -> logrus

### DIFF
--- a/internal/clients/client.go
+++ b/internal/clients/client.go
@@ -3,7 +3,7 @@ package clients
 import (
 	"errors"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 
 	cloud_network "github.com/hashicorp/hcp-sdk-go/clients/cloud-network/preview/2020-09-07/client"

--- a/internal/clients/hvn_route.go
+++ b/internal/clients/hvn_route.go
@@ -3,7 +3,7 @@ package clients
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/hashicorp/hcp-sdk-go/clients/cloud-network/preview/2020-09-07/client/network_service"

--- a/internal/clients/logging.go
+++ b/internal/clients/logging.go
@@ -2,7 +2,7 @@ package clients
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"os"
 	"strings"
 )

--- a/internal/clients/operation.go
+++ b/internal/clients/operation.go
@@ -3,7 +3,7 @@ package clients
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/hashicorp/hcp-sdk-go/clients/cloud-operation/preview/2020-05-05/client/operation_service"

--- a/internal/provider/data_source_aws_network_peering.go
+++ b/internal/provider/data_source_aws_network_peering.go
@@ -3,7 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/hashicorp/hcp-sdk-go/clients/cloud-network/preview/2020-09-07/models"
 	sharedmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-shared/v1/models"

--- a/internal/provider/data_source_azure_peering_connection.go
+++ b/internal/provider/data_source_azure_peering_connection.go
@@ -3,7 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/hashicorp/hcp-sdk-go/clients/cloud-network/preview/2020-09-07/models"
 	sharedmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-shared/v1/models"

--- a/internal/provider/data_source_boundary_cluster.go
+++ b/internal/provider/data_source_boundary_cluster.go
@@ -2,7 +2,7 @@ package provider
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 
 	sharedmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-shared/v1/models"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"

--- a/internal/provider/data_source_consul_cluster.go
+++ b/internal/provider/data_source_consul_cluster.go
@@ -3,7 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 
 	consulmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-consul-service/stable/2021-02-04/models"
 	sharedmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-shared/v1/models"

--- a/internal/provider/data_source_hvn.go
+++ b/internal/provider/data_source_hvn.go
@@ -2,7 +2,7 @@ package provider
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 
 	sharedmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-shared/v1/models"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"

--- a/internal/provider/data_source_hvn_peering_connection.go
+++ b/internal/provider/data_source_hvn_peering_connection.go
@@ -2,7 +2,7 @@ package provider
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 
 	sharedmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-shared/v1/models"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"

--- a/internal/provider/data_source_hvn_route.go
+++ b/internal/provider/data_source_hvn_route.go
@@ -2,7 +2,7 @@ package provider
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 
 	sharedmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-shared/v1/models"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"

--- a/internal/provider/data_source_packer_image.go
+++ b/internal/provider/data_source_packer_image.go
@@ -2,7 +2,7 @@ package provider
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	packermodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-packer-service/stable/2021-04-30/models"

--- a/internal/provider/data_source_packer_image_iteration.go
+++ b/internal/provider/data_source_packer_image_iteration.go
@@ -2,7 +2,7 @@ package provider
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	packermodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-packer-service/stable/2021-04-30/models"

--- a/internal/provider/data_source_packer_iteration.go
+++ b/internal/provider/data_source_packer_iteration.go
@@ -2,7 +2,7 @@ package provider
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	sharedmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-shared/v1/models"

--- a/internal/provider/data_source_vault_cluster.go
+++ b/internal/provider/data_source_vault_cluster.go
@@ -2,7 +2,7 @@ package provider
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 
 	sharedmodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-shared/v1/models"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"

--- a/internal/provider/resource_aws_network_peering.go
+++ b/internal/provider/resource_aws_network_peering.go
@@ -2,7 +2,7 @@ package provider
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 
 	"github.com/hashicorp/hcp-sdk-go/clients/cloud-network/preview/2020-09-07/client/network_service"

--- a/internal/provider/resource_aws_transit_gateway_attachment.go
+++ b/internal/provider/resource_aws_transit_gateway_attachment.go
@@ -3,7 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"time"
 

--- a/internal/provider/resource_azure_peering_connection.go
+++ b/internal/provider/resource_azure_peering_connection.go
@@ -2,7 +2,7 @@ package provider
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 
 	"github.com/hashicorp/hcp-sdk-go/clients/cloud-network/preview/2020-09-07/client/network_service"

--- a/internal/provider/resource_boundary_cluster.go
+++ b/internal/provider/resource_boundary_cluster.go
@@ -2,7 +2,7 @@ package provider
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	boundarymodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-boundary-service/preview/2021-12-21/models"

--- a/internal/provider/resource_consul_cluster.go
+++ b/internal/provider/resource_consul_cluster.go
@@ -3,7 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"time"
 

--- a/internal/provider/resource_consul_cluster_root_token.go
+++ b/internal/provider/resource_consul_cluster_root_token.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"path/filepath"
 	"strings"
 	"time"

--- a/internal/provider/resource_consul_snapshot.go
+++ b/internal/provider/resource_consul_snapshot.go
@@ -2,7 +2,7 @@ package provider
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strconv"
 	"time"
 

--- a/internal/provider/resource_hvn.go
+++ b/internal/provider/resource_hvn.go
@@ -2,7 +2,7 @@ package provider
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"time"
 

--- a/internal/provider/resource_hvn_peering_connection.go
+++ b/internal/provider/resource_hvn_peering_connection.go
@@ -2,7 +2,7 @@ package provider
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 
 	"github.com/hashicorp/hcp-sdk-go/clients/cloud-network/preview/2020-09-07/client/network_service"

--- a/internal/provider/resource_hvn_route.go
+++ b/internal/provider/resource_hvn_route.go
@@ -3,7 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"time"
 

--- a/internal/provider/resource_packer_channel.go
+++ b/internal/provider/resource_packer_channel.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 
 	packermodels "github.com/hashicorp/hcp-sdk-go/clients/cloud-packer-service/stable/2021-04-30/models"

--- a/internal/provider/resource_vault_cluster.go
+++ b/internal/provider/resource_vault_cluster.go
@@ -3,7 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"time"
 

--- a/internal/provider/resource_vault_cluster_admin_token.go
+++ b/internal/provider/resource_vault_cluster_admin_token.go
@@ -3,7 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/hashicorp/hcp-sdk-go/clients/cloud-shared/v1/models"


### PR DESCRIPTION
Use logrus for logging instead of standard log library

[_Created by Sourcegraph batch change `admin/use-logrus-in-terraform-providers`._](https://gcp.s0urcegraph.com/users/admin/batch-changes/use-logrus-in-terraform-providers)